### PR TITLE
Enhanced eslit+prettier configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,41 +1,39 @@
 module.exports = {
-  "env": {
-    "browser": true,
-    "es6": true,
-    "node": true
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
   },
-  "settings": {
-    "react": {
-      "createClass": "createReactClass", // Regex for Component Factory to use,
-                                         // default to "createReactClass"
-      "pragma": "React",  // Pragma to use, default to "React"
-      "version": "detect"
-    }
-  },
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
-  ],
-  "globals": {
-    "Atomics": "readonly",
-    "SharedArrayBuffer": "readonly"
-  },
-  "parser": "babel-eslint",
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
+  settings: {
+    react: {
+      createClass: 'createReactClass', // Regex for Component Factory to use,
+      // default to "createReactClass"
+      pragma: 'React', // Pragma to use, default to "React"
+      version: 'detect',
     },
-    "ecmaVersion": 2018,
-    "sourceType": "module"
   },
-  "plugins": [
-    "react",
-    "class-property"
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:prettier/recommended',
   ],
-  "rules": {
-    "no-console": "off",
-    "react/prop-types": 0,
-    "object-curly-spacing": ["error", "always"],
-    "brace-style":  ["error", "1tbs", { "allowSingleLine": true }]
-  }
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly',
+  },
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+  plugins: ['react', 'class-property'],
+  rules: {
+    'no-console': 'off',
+    'react/prop-types': 0,
+    'object-curly-spacing': ['error', 'always'],
+    'brace-style': ['error', '1tbs', { allowSingleLine: true }]
+  },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ bower_components
 *.swp
 package-lock.json
 .idea
+/.vscode/
 dist

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ Examples:
 #### Styled Components
 - Use “Styled” prefix for styled components. It will helps you yo understand in code what kind of components you are using. For example, if you override some styles for NoteComponent, please, gave it “StyledNote” name.
 
+#### Codestyle
+
+The project uses eslint + prettier configuration. To use it fully, configure your editor. Here is a configuration example for vscode:
+
+```
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}
+```
+
+Short explanation how it works:
+
+Eslint uses `eslint-config-prettier` which uses `eslint-plugin-prettier` behind the scene as special rule and avoids conflicts with defined eslint rules.
+
 ## Launch locally
 ```
 git clone https://github.com/DarthVanger/NeuralNotes.git

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
     "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^2.1.0",
     "eslint": "^5.16.0",
+    "eslint-config-prettier": "^6.9.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-class-property": "^1.1.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-standard": "^4.0.0",
@@ -54,7 +56,7 @@
     "husky": "^4.0.10",
     "image-webpack-loader": "^4.6.0",
     "lint-staged": "^10.0.0",
-    "prettier": "^1.19.1",
+    "prettier": "1.19.1",
     "react-hot-loader": "^4.8.3",
     "redux-devtools-extension": "^2.13.8",
     "scriptjs": "^2.5.9",
@@ -77,8 +79,8 @@
     }
   },
   "lint-staged": {
-    "./src/*.{js,html,css}": [
-      "npx prettier --write"
+    "./src/**/*.{js,html,css}": [
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
*What was the problem?*

1. We need to use exact prettier version because prettier rules could be changed
2. `lint-staged`  files pattern was incorrect - it wasn't worked for nested files, only for root files
3. We need to resolve conflicts between `eslint` and `prettier` rules and formatting
4. We need an easy way for a developer to be sure that the code style is consistent: just usage of prettier is not enough, just usage or eslint (independently from prettier) is not enough. If link them together and use eslint + prettier (behind the scene) would be great. Better to use auto-formatting in the editor

All the above are fixed in this PR.