### PR TITLE
Add 'vis-network' dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "redux-actions": "^2.6.5",
     "redux-saga": "^1.0.2",
     "socket.io": "^1.4.6",
-    "styled-components": "^4.3.1"
+    "styled-components": "^4.3.1",
+    "vis-network": "^6.4.8"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.0",


### PR DESCRIPTION
We use 'vis-network' in our product but it was not added to
dependencies. Now we do it.