### PR TITLE
delete: unnecessary gapi load()

### DIFF
--- a/src/components/App/AppSagas.js
+++ b/src/components/App/AppSagas.js
@@ -17,10 +17,8 @@ import { push } from 'connected-react-router';
 
 export function* loadApp() {
   console.info('Loading app...');
-
   // yield showSpinner('Loading Google Api');
-  yield googleApiLoader.load();
-  yield googleDriveApi.loadDriveApi();
+
   let initialNote;
   const lastViewedNoteId = localStorage.getItem('lastViewedNoteId');
   if (lastViewedNoteId) {
@@ -35,6 +33,9 @@ export function* loadApp() {
 }
 
 export function* appInit() {
+  yield googleApiLoader.load();
+  yield googleDriveApi.loadDriveApi();
+
   yield call([toast, toast.configure], {
     position: toast.POSITION.BOTTOM_RIGHT,
   });

--- a/src/components/LoginPage/LoginPageSagas.js
+++ b/src/components/LoginPage/LoginPageSagas.js
@@ -13,7 +13,6 @@ import {
   requestAuth,
   authSuccess,
 } from 'components/LoginPage/LoginPageSlice';
-import googleApiLoader from 'api/google-api-loader';
 
 export function* handleAuth() {
   const spinnerName = 'Loading google auth';
@@ -34,7 +33,6 @@ export function* handleAuth() {
 }
 
 export function* loginInit() {
-  yield googleApiLoader.load();
   yield put(initGapi());
   yield takeEvery(requestAuth().type, handleAuth);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,19 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import * as ReactDOM from 'react-dom';
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
-
 import 'vis-network/dist/vis-network.css';
 import 'react-toastify/dist/ReactToastify.css';
 import 'sagas';
 import { App } from 'components/App/App';
 import { store, history } from 'sagas';
 import { GlobalStyle } from 'globalStyles';
-
 import { ConnectedRouter } from 'connected-react-router';
+
+// The app flow is following:
+// 1) The global code is executed. So it you have for example console.log() at the root of file it will execute
+// 2) redux-saga is imported before React, so saga's run() function will execute, and all effects will run in parallel
+// 3) The code inside React components will execute
+// 4) Saga's effects finish executing
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import { GlobalStyle } from 'globalStyles';
 import { ConnectedRouter } from 'connected-react-router';
 
 // The app flow is following:
-// 1) The global code is executed. So it you have for example console.log() at the root of file it will execute
+// 1) The global code is executed. So if you have for example console.log() at the root of file it will execute
 // 2) redux-saga is imported before React, so saga's run() function will execute, and all effects will run in parallel
 // 3) The code inside React components will execute
 // 4) Saga's effects finish executing

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import { GlobalStyle } from 'globalStyles';
 import { ConnectedRouter } from 'connected-react-router';
 
 // The app flow is following:
-// 1) The global code is executed. So if you have for example console.log() at the root of file it will execute
+// 1) The global code is executed. So if you have first line in js file like console.log() it will be execute
 // 2) redux-saga is imported before React, so saga's run() function will execute, and all effects will run in parallel
 // 3) The code inside React components will execute
 // 4) Saga's effects finish executing


### PR DESCRIPTION
loading Google API happens in 2 files:
![2-files](https://user-images.githubusercontent.com/45026388/97769148-d988bd80-1b6b-11eb-8ac4-9fdb7b678b8f.png)

in app it's:
![app](https://user-images.githubusercontent.com/45026388/97769160-ea393380-1b6b-11eb-895b-449cbbfdba0c.png)

and in login:
![login](https://user-images.githubusercontent.com/45026388/97769166-fa511300-1b6b-11eb-8ba9-34a0c9834b00.png)

The app works fine with only 1 call to `load()`
![fine](https://user-images.githubusercontent.com/45026388/97769178-0fc63d00-1b6c-11eb-99e2-ec804db38e5f.png)

