### PR TITLE
remove unnecessary check from UploadButton

### DIFF
--- a/src/components/Uploads/UploadButton.js
+++ b/src/components/Uploads/UploadButton.js
@@ -4,7 +4,6 @@ import Fab from '@material-ui/core/Fab';
 import { makeStyles } from '@material-ui/core/styles';
 import PublishIcon from '@material-ui/icons/Publish';
 import { useDispatch, useSelector } from 'react-redux';
-import { CSSTransition } from 'react-transition-group';
 import { NotesMindMapSelectors } from 'selectors';
 
 import { UploadsActions } from './UploadsActions';
@@ -38,9 +37,6 @@ export function UploadButton() {
   }
   const classes = useStyles();
   const dispatch = useDispatch();
-  const isUploadButtonVisible = useSelector(
-    NotesMindMapSelectors.isSelectedNoteRealNote,
-  );
   const uploadFolderId = useSelector(NotesMindMapSelectors.getSelectedNoteId);
   const fileInputRef = React.createRef();
 
@@ -53,15 +49,13 @@ export function UploadButton() {
         style={{ display: 'none' }}
         onChange={handleSelectedFiles}
       />
-      <CSSTransition in={isUploadButtonVisible} timeout={200} unmountOnExit>
-        <Fab
-          aria-label="upload"
-          onClick={onUploadButtonClick}
-          className={classes.fabButton}
-          color="secondary.button">
-          <PublishIcon />
-        </Fab>
-      </CSSTransition>
+      <Fab
+        aria-label="upload"
+        onClick={onUploadButtonClick}
+        className={classes.fabButton}
+        color="secondary.button">
+        <PublishIcon />
+      </Fab>
     </>
   );
 }


### PR DESCRIPTION
We do not need this check anymore in the UploadButton component as I see. Because we have the same kind of check in the BottomBar component `selectedNote.isNote`. Also, it is causing to the situation when we can not display UploadButton for root note.