### PR TITLE
Fix attributes BottomBarMenu.js error.

### DIFF
--- a/src/components/BottomBar/BottomBarMenu.js
+++ b/src/components/BottomBar/BottomBarMenu.js
@@ -71,7 +71,7 @@ export const BottomBarMenu = () => {
         keepMounted
         open={isMenuOpened}
         onClose={closeMenu}
-        aperProps={{
+        PaperProps={{
           style: {
             width: '168px',
           },


### PR DESCRIPTION
Fix error:

```react-dom.development.js:88 Warning: React does not recognize the `aperProps` prop on a DOM element.```