### PR TITLE
Refactor styles NoteDetailsPage

### DIFF
--- a/src/components/NoteDetails/NoteDetailsPage.js
+++ b/src/components/NoteDetails/NoteDetailsPage.js
@@ -4,16 +4,16 @@ import IconButton from '@material-ui/core/IconButton';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { colors } from 'colors';
 
 import { NoteDetailsContainer } from 'components/NoteDetails/NoteDetailsContainer';
 
 const Wrapper = styled.div`
-  background-color: #2b2630;
+  background-color: ${colors.darkViolet};
 `;
 
 const BackButtonWrapper = styled.div`
-  color: red !important;
-  padding: 1rem;
+  padding: 0.5rem;
 `;
 
 export const NoteDetailsPage = () => {
@@ -22,7 +22,7 @@ export const NoteDetailsPage = () => {
       <BackButtonWrapper>
         <Link to="/notes">
           <IconButton aria-label="back">
-            <ArrowBackIcon style={{ fill: '#E4E3E4' }} />
+            <ArrowBackIcon style={{ fill: colors.white60 }} />
           </IconButton>
         </Link>
       </BackButtonWrapper>


### PR DESCRIPTION
In the project uses connected-react-router, and for some reason <Link> is used for navigation, although {push} should be used [connected-react-router](https://github.com/supasate/connected-react-router/blob/master/FAQ.md#how-to-navigate-with-redux-action)
Perhaps the component should use <TopBar> instead of <BackButtonWrapper> as a template for the topbar.
Or is it a separate ticket? 
