### PR TITLE
Removed headline6 in themes

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -13,13 +13,6 @@ export const theme = createMuiTheme({
     },
   },
   typography: {
-    headline6: {
-      fontFamily: 'Roboto',
-      fontStyle: 'normal',
-      fontWeight: 500,
-      fontSize: '19px',
-      lineHeight: '22px',
-    },
     subtitle1: {
       fontFamily: 'Roboto',
       fontStyle: 'normal',


### PR DESCRIPTION
I checked the project - this style was not used anywhere. 